### PR TITLE
allow additional scopes at signin

### DIFF
--- a/GoogleSignIn/Sources/GIDSignIn.m
+++ b/GoogleSignIn/Sources/GIDSignIn.m
@@ -203,23 +203,36 @@ static const NSTimeInterval kMinimumRestoredAccessTokenTimeToExpire = 600.0;
 
 - (void)signInWithConfiguration:(GIDConfiguration *)configuration
        presentingViewController:(UIViewController *)presentingViewController
-                           hint:(nullable NSString *)hint
-                       callback:(nullable GIDSignInCallback)callback {
-  GIDSignInInternalOptions *options =
-      [GIDSignInInternalOptions defaultOptionsWithConfiguration:configuration
-                                       presentingViewController:presentingViewController
-                                                      loginHint:hint
-                                                       callback:callback];
-  [self signInWithOptions:options];
-}
-
-- (void)signInWithConfiguration:(GIDConfiguration *)configuration
-       presentingViewController:(UIViewController *)presentingViewController
                        callback:(nullable GIDSignInCallback)callback {
   [self signInWithConfiguration:configuration
        presentingViewController:presentingViewController
                            hint:nil
                        callback:callback];
+}
+
+- (void)signInWithConfiguration:(GIDConfiguration *)configuration
+       presentingViewController:(UIViewController *)presentingViewController
+                           hint:(nullable NSString *)hint
+                       callback:(nullable GIDSignInCallback)callback {
+  [self signInWithConfiguration:configuration
+               additionalScopes:@[]
+       presentingViewController:presentingViewController
+                           hint:hint
+                       callback:callback];
+}
+
+- (void)signInWithConfiguration:(GIDConfiguration *)configuration
+               additionalScopes:(NSArray<NSString *> *)additionalScopes
+       presentingViewController:(UIViewController *)presentingViewController
+                           hint:(nullable NSString *)hint
+                       callback:(nullable GIDSignInCallback)callback {
+  GIDSignInInternalOptions *options =
+      [GIDSignInInternalOptions defaultOptionsWithConfiguration:configuration
+                                               additionalScopes:additionalScopes
+                                       presentingViewController:presentingViewController
+                                                      loginHint:hint
+                                                       callback:callback];
+  [self signInWithOptions:options];
 }
 
 - (void)addScopes:(NSArray<NSString *> *)scopes

--- a/GoogleSignIn/Sources/GIDSignInInternalOptions.h
+++ b/GoogleSignIn/Sources/GIDSignInInternalOptions.h
@@ -56,6 +56,14 @@ NS_ASSUME_NONNULL_BEGIN
                                       loginHint:(nullable NSString *)loginHint
                                        callback:(GIDSignInCallback)callback;
 
+/// Creates the default options, with the ability to add additional scopes.
++ (instancetype)defaultOptionsWithConfiguration:(nullable GIDConfiguration *)configuration
+                               additionalScopes:(NSArray<NSString *> *)additionalScopes
+                       presentingViewController:
+                           (nullable UIViewController *)presentingViewController
+                                      loginHint:(nullable NSString *)loginHint
+                                       callback:(GIDSignInCallback)callback;
+
 /// Creates the options to sign in silently.
 + (instancetype)silentOptionsWithCallback:(GIDSignInCallback)callback;
 

--- a/GoogleSignIn/Sources/GIDSignInInternalOptions.m
+++ b/GoogleSignIn/Sources/GIDSignInInternalOptions.m
@@ -25,6 +25,19 @@ NS_ASSUME_NONNULL_BEGIN
                            (nullable UIViewController *)presentingViewController
                                       loginHint:(nullable NSString *)loginHint
                                        callback:(GIDSignInCallback)callback {
+  return [self defaultOptionsWithConfiguration:configuration
+                              additionalScopes:@[]
+                      presentingViewController:presentingViewController
+                                     loginHint:loginHint
+                                      callback:callback];
+}
+
++ (instancetype)defaultOptionsWithConfiguration:(nullable GIDConfiguration *)configuration
+                               additionalScopes:(NSArray<NSString *> *)additionalScopes
+                       presentingViewController:
+                           (nullable UIViewController *)presentingViewController
+                                      loginHint:(nullable NSString *)loginHint
+                                       callback:(GIDSignInCallback)callback {
   GIDSignInInternalOptions *options = [[GIDSignInInternalOptions alloc] init];
   if (options) {
     options->_interactive = YES;
@@ -33,7 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
     options->_presentingViewController = presentingViewController;
     options->_loginHint = loginHint;
     options->_callback = callback;
-    options->_scopes = [GIDScopes scopesWithBasicProfile:@[]];
+    options->_scopes = [GIDScopes scopesWithBasicProfile:additionalScopes];
   }
   return options;
 }

--- a/GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h
+++ b/GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h
@@ -126,6 +126,29 @@ typedef void (^GIDDisconnectCallback)(NSError *_Nullable error);
                            hint:(nullable NSString *)hint
                        callback:(nullable GIDSignInCallback)callback;
 
+/// Starts an interactive sign-in flow using the provided configuration and a login hint.
+///
+/// The callback will be called at the end of this process.  Any saved sign-in state will be
+/// replaced by the result of this flow.  Note that this method should not be called when the app is
+/// starting up, (e.g in `application:didFinishLaunchingWithOptions:`); instead use the
+/// `restorePreviousSignInWithCallback:` method to restore a previous sign-in.
+///
+/// @param configuration The configuration properties to be used for this flow.
+/// @param additionalScopes Additional scopes to request
+/// @param presentingViewController The view controller used to present `SFSafariViewContoller` on
+///     iOS 9 and 10 and to supply `presentationContextProvider` for `ASWebAuthenticationSession` on
+///     iOS 13+.
+/// @param hint An optional hint for the authorization server, for example the user's ID or email
+///     address, to be prefilled if possible.
+/// @param callback The `GIDSignInCallback` block that is called on completion.  This block will be
+///     called asynchronously on the main queue.
+- (void)signInWithConfiguration:(GIDConfiguration *)configuration
+               additionalScopes:(NSArray<NSString *> *)additionalScopes
+       presentingViewController:(UIViewController *)presentingViewController
+                           hint:(nullable NSString *)hint
+                       callback:(nullable GIDSignInCallback)callback;
+
+
 /// Starts an interactive consent flow to add scopes to the current user's grants.
 ///
 /// The callback will be called at the end of this process.  If successful, a new `GIDGoogleUser`

--- a/GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h
+++ b/GoogleSignIn/Sources/Public/GoogleSignIn/GIDSignIn.h
@@ -148,7 +148,6 @@ typedef void (^GIDDisconnectCallback)(NSError *_Nullable error);
                            hint:(nullable NSString *)hint
                        callback:(nullable GIDSignInCallback)callback;
 
-
 /// Starts an interactive consent flow to add scopes to the current user's grants.
 ///
 /// The callback will be called at the end of this process.  If successful, a new `GIDGoogleUser`


### PR DESCRIPTION
Right now you have to log in and you're granted Profile & Email scopes, but then you have to go through the flow again to request additional scopes for email, calendar. Because we sign in with Google in order to link to your calendar, this results in a super annoying double-login prompt.
Adding functionality to request these additional scopes when you first sign in